### PR TITLE
Fixes for Finamp Beta offline import

### DIFF
--- a/src/offline-import.js
+++ b/src/offline-import.js
@@ -103,7 +103,7 @@ const uploadOfflinePlaybackQuery = (offlinePlays, auth) => {
   (DateCreated, UserId, ItemId, ItemType, ItemName, PlaybackMethod, ClientName, DeviceName, PlayDuration)
   VALUES
     ${offlinePlays.map(play => 
-      `( '${play.timestamp.toISOString().slice(0, 19).replace(`T`, ` `)}.0000000', '${auth.config.user.id}', '${play.itemId}', 'Audio', '${play.artist.replaceAll(`'`, `''`)} - ${play.title.replaceAll(`'`, `''`)} (${play.album.replaceAll(`'`, `''`)})', 'OfflinePlay', '${play.client.replaceAll(`'`, `''`)}', '${play.device.replaceAll(`'`, `''`)}', ${play.playDuration})`
+      `( '${play.timestamp.toISOString().slice(0, 19).replace(`T`, ` `)}.0000000', '${auth.config.user.id}', '${play.itemId}', 'Audio', '${play.artist.replaceAll(`'`, `''`)} - ${play.title.replaceAll(`'`, `''`)} (${play.album?.replaceAll(`'`, `''`) ?? ''})', 'OfflinePlay', '${play.client.replaceAll(`'`, `''`)}', '${play.device.replaceAll(`'`, `''`)}', ${play.playDuration ?? 0})`
     ).join(`,`)}
   `
 }
@@ -114,6 +114,7 @@ export async function uploadOfflinePlayback(offlinePlays, auth) {
 
   console.info(`Importing offline playback to server`)
   
+
   const response = await fetch(`${auth.config.baseUrl}/user_usage_stats/submit_custom_query?stamp=${Date.now()}`, {
     method: 'POST',
     headers: {


### PR DESCRIPTION
- loadItemInfo was returning a 414 URI Too Long for me, so I made it do multiple requests instead by chunking the ids (I arbitrarily chose 200 as the chunk size)
- The generated SQL query for offline plays was sometimes `undefined` for the album and play duration, so I added fallbacks for those