### PR TITLE
Use old report's year in page content

### DIFF
--- a/src/features.js
+++ b/src/features.js
@@ -626,7 +626,7 @@ state.features = [
       <h3 class="text-2xl font-medium">...compared to last year!</h3>
       
       <div class="mt-24 w-full px-6 flex flex-col items-center gap-2">
-        <div class="font-semibold text-xl">This year, you played <span class="font-semibold text-3xl text-sky-500 font-quicksand">${() => state.extraFeatures.listeningActivityDifference ? showAsNumber(Math.abs(state.rewindReport?.featureDelta?.listeningActivityDifference?.totalPlays[state.settings.dataSource]).toFixed(0)) : `???`}</span> tracks ${() => (!state.extraFeatures.listeningActivityDifference || state.rewindReport?.featureDelta?.listeningActivityDifference?.totalPlays[state.settings.dataSource] >= 0) ? `more` : `less`} than in ${() => state.rewindReport?.year}.</div>
+        <div class="font-semibold text-xl">This year, you played <span class="font-semibold text-3xl text-sky-500 font-quicksand">${() => state.extraFeatures.listeningActivityDifference ? showAsNumber(Math.abs(state.rewindReport?.featureDelta?.listeningActivityDifference?.totalPlays[state.settings.dataSource]).toFixed(0)) : `???`}</span> tracks ${() => (!state.extraFeatures.listeningActivityDifference || state.rewindReport?.featureDelta?.listeningActivityDifference?.totalPlays[state.settings.dataSource] >= 0) ? `more` : `less`} than in ${() => state.rewindReport?.oldReportYear}.</div>
       </div>
       
       <div class="mt-28 w-full px-10 flex flex-col items-center gap-3">

--- a/src/rewind.js
+++ b/src/rewind.js
@@ -552,7 +552,8 @@ async function generateRewindReport({
     
     if (oldReport) {
       const featureDelta = await getFeatureDelta(oldReport, { jellyfinRewindReport })
-  
+      
+      jellyfinRewindReport.oldReportYear = oldReport.jellyfinRewindReport?.year
       jellyfinRewindReport.featureDelta = featureDelta
     }
     


### PR DESCRIPTION
Fixes #27

Uses year property from old report's data.

![image](https://github.com/user-attachments/assets/8a7c728f-e71c-4327-a155-66e6154d92e5)
